### PR TITLE
Do not swallow network errors

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -102,7 +102,14 @@ Now.prototype = {
         })
 
         .catch(err => {
-          const errData = err.data.err ? err.data.err : err.data
+          let errData
+          if (err.data && err.data.err) {
+            errData = err.data.err
+          } else if (err.data) {
+            errData = err.data
+          } else {
+            errData = err.toString()
+          }
           reject(errData)
           this.handleCallback(callback, errData)
         })

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,16 @@ describe('Now', function tests() {
     })
   })
 
+  it('should return error on timeout (and other network errors)', () => {
+    const nowWithShortTimeout = new Now(TOKEN)
+    nowWithShortTimeout.axios.defaults.timeout = 1
+    return nowWithShortTimeout.getDeployments().then(() => {
+      throw new Error('promise should be rejected due to timeout')
+    }).catch(err => {
+      err.should.be.a('string')
+    })
+  })
+
   it('should retrieve deployments via callback', done => {
     now.getDeployments((err, data) => {
       if (err) {


### PR DESCRIPTION
Currently network errors are swallowed and promises never got resolved nor rejected. This PR handles this by promise reject with text message.