### PR TITLE
Fix error response parsing

### DIFF
--- a/src/now.js
+++ b/src/now.js
@@ -107,8 +107,8 @@ Now.prototype = {
 
         .catch(err => {
           let errData
-          if (err.data && err.data.err) {
-            errData = err.data.err
+          if (err.response.data.error) {
+            errData = err.response.data.error
           } else if (err.data) {
             errData = err.data
           } else {


### PR DESCRIPTION
If the error is returned by the API we should get the following object:
```
{ code: 'CODE',
  message: 'Went foobar' }
```
