### PR TITLE
docs: fix link to api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Changes the name of the given secret and returns its ID and name.
 Deletes a secret and returns its ID.
 
 **Kind**: instance method of <code>[Now](#Now)</code>  
-**See**: https://zeit.co/api#delete-user-aliases  
+**See**: https://zeit.co/api#delete-now-secrets  
 
 | Param | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
I noticed one of the links to the docs on the now homepage was incorrect, so I fixed it.