### PR TITLE
docs: fix see url for delete secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Changes the name of the given secret and returns its ID and name.
 Deletes a secret and returns its ID.
 
 **Kind**: instance method of <code>[Now](#Now)</code>  
-**See**: https://zeit.co/api#delete-user-aliases  
+**See**: https://zeit.co/api#delete-now-secrets  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/src/now.js
+++ b/src/now.js
@@ -370,7 +370,7 @@ Now.prototype = {
    * @return {Promise}
    * @param  {String} id     ID or name of the secret
    * @param  {Function} [callback]     Callback will be called with `(err, status)`
-   * @see https://zeit.co/api#delete-user-aliases
+   * @see https://zeit.co/api#delete-now-secrets
    */
   deleteSecret: function deleteSecret(id, callback) {
     if (!id) {


### PR DESCRIPTION
fix "see" link to api docs for delete secrets and regenerated README.
follow up to PR #39 