### PR TITLE
Add support for `teamId`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ function _getToken() {
 const handleError = err => new Promise((resolve, reject) => reject(err))
 
 class Now {
-  constructor(token = _getToken()) {
+  constructor(token = _getToken(), teamId) {
     if (!token) {
       console.error(
         'No token found! ' +
@@ -67,6 +67,9 @@ class Now {
       baseUrl: 'https://api.zeit.co',
       timeout: 30000,
       json: true,
+      qs: {
+        teamId
+      },
       headers: {
         Authorization: `Bearer ${token}`
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "now-client",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Node.js wrapper for the 𝚫 now instant API",
   "main": "lib/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ const nowClient = require('now-client')
 Then initialize it using your token:
 
 ```js
-const now = nowClient('YOUR TOKEN')
+const now = new nowClient('YOUR TOKEN')
 ```
 
 And finally, you can use its methods to retrieve data:

--- a/readme.md
+++ b/readme.md
@@ -18,13 +18,13 @@ npm install --save now-client
 Firstly, load the package:
 
 ```js
-const nowClient = require('now-client')
+const NowClient = require('now-client')
 ```
 
 Then initialize it using your token:
 
 ```js
-const now = new nowClient('YOUR TOKEN')
+const now = new NowClient('YOUR TOKEN')
 ```
 
 And finally, you can use its methods to retrieve data:


### PR DESCRIPTION
Added support for `teamId` with the following in mind:

1. No breaking change. The `teamId` is not read from `~/.now.json` to keep the same behavior as before.
2. Tests. All current tests run and pass, but I'm wondering how to add new tests for the team feature. With some guidance I'll gladly add it.

Addresses #63 