### PR TITLE
Update now config file location

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,8 +41,8 @@ function _getToken() {
 
   if (!token) {
     try {
-      const configPath = path.join(os.homedir(), '.now.json')
-      token = require(configPath).token // eslint-disable-line global-require, import/no-dynamic-require
+      const configPath = path.join(os.homedir(), '.now/auth.json')
+      token = require(configPath).credentials.token // eslint-disable-line global-require, import/no-dynamic-require
     } catch (err) {
       console.error(`Error: ${err}`)
     }


### PR DESCRIPTION
According to the `now-cli` [documentation](https://github.com/zeit/now-cli#global-configuration), the configuration file has moved from `.now.json` to `.now/auth.json`.