### PR TITLE
Update location of authentication file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function _getToken() {
   if (!token) {
     try {
       const configPath = path.join(os.homedir(), '.now/auth.json')
-      token = require(configPath).credentials.token // eslint-disable-line global-require, import/no-dynamic-require
+      token = require(configPath).credentials[0].token // eslint-disable-line global-require, import/no-dynamic-require
     } catch (err) {
       console.error(`Error: ${err}`)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,8 @@ function _getToken() {
   if (!token) {
     try {
       const configPath = path.join(os.homedir(), '.now/auth.json')
-      ({ token } = require(configPath).credentials.find(item => item.provider === 'sh')) // eslint-disable-line global-require, import/no-dynamic-require
+      const { credentials } = require(configPath) // eslint-disable-line global-require, import/no-dynamic-require
+      token = credentials.find(item => item.provider === 'sh').token
     } catch (err) {
       console.error(`Error: ${err}`)
     }
@@ -58,8 +59,8 @@ class Now {
     if (!token) {
       console.error(
         'No token found! ' +
-        'Supply it as argument or use the NOW_TOKEN env variable. ' +
-        '`~/.now/auth.json` will be used, if it\'s found in your home directory.'
+          'Supply it as argument or use the NOW_TOKEN env variable. ' +
+          "`~/.now/auth.json` will be used, if it's found in your home directory."
       )
     }
 
@@ -96,10 +97,13 @@ class Now {
     })
   }
   getDeployments() {
-    return this.handleRequest({
-      url: '/now/deployments',
-      method: 'get'
-    }, 'deployments')
+    return this.handleRequest(
+      {
+        url: '/now/deployments',
+        method: 'get'
+      },
+      'deployments'
+    )
   }
 
   getDeployment(id) {
@@ -163,10 +167,13 @@ class Now {
   }
 
   getDomains() {
-    return this.handleRequest({
-      url: '/domains',
-      method: 'get'
-    }, 'domains')
+    return this.handleRequest(
+      {
+        url: '/domains',
+        method: 'get'
+      },
+      'domains'
+    )
   }
 
   addDomain(domain) {
@@ -196,10 +203,13 @@ class Now {
   }
 
   getDomainRecords(domain) {
-    return this.handleRequest({
-      url: `/domains/${domain}/records`,
-      method: 'get'
-    }, 'records')
+    return this.handleRequest(
+      {
+        url: `/domains/${domain}/records`,
+        method: 'get'
+      },
+      'records'
+    )
   }
 
   addDomainRecord(domain, recordData) {
@@ -224,10 +234,13 @@ class Now {
       url += `/now/${cn}`
     }
 
-    return this.handleRequest({
-      url,
-      method: 'get'
-    }, 'certs')
+    return this.handleRequest(
+      {
+        url,
+        method: 'get'
+      },
+      'certs'
+    )
   }
 
   createCertificate(cn) {
@@ -260,16 +273,19 @@ class Now {
   }
 
   replaceCertificate(cn, cert, key, ca) {
-    return this.handleRequest({
-      url: '/now/certs',
-      method: 'put',
-      body: {
-        domains: [cn],
-        ca,
-        cert,
-        key
-      }
-    }, 'created')
+    return this.handleRequest(
+      {
+        url: '/now/certs',
+        method: 'put',
+        body: {
+          domains: [cn],
+          ca,
+          cert,
+          key
+        }
+      },
+      'created'
+    )
   }
 
   deleteCertificate(cn) {
@@ -290,10 +306,13 @@ class Now {
       url = `/now/deployments/${id}/aliases`
     }
 
-    return this.handleRequest({
-      url,
-      method: 'get'
-    }, 'aliases')
+    return this.handleRequest(
+      {
+        url,
+        method: 'get'
+      },
+      'aliases'
+    )
   }
 
   createAlias(id, alias) {
@@ -326,10 +345,13 @@ class Now {
   }
 
   getSecrets() {
-    return this.handleRequest({
-      url: '/now/secrets',
-      method: 'get'
-    }, 'secrets')
+    return this.handleRequest(
+      {
+        url: '/now/secrets',
+        method: 'get'
+      },
+      'secrets'
+    )
   }
 
   createSecret(name, value) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function _getToken() {
   if (!token) {
     try {
       const configPath = path.join(os.homedir(), '.now/auth.json')
-      token = require(configPath).credentials[0].token // eslint-disable-line global-require, import/no-dynamic-require
+      ({ token } = require(configPath).credentials.find(item => item.provider === 'sh')) // eslint-disable-line global-require, import/no-dynamic-require
     } catch (err) {
       console.error(`Error: ${err}`)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,8 +59,8 @@ class Now {
     if (!token) {
       console.error(
         'No token found! ' +
-          'Supply it as argument or use the NOW_TOKEN env variable. ' +
-          "`~/.now/auth.json` will be used, if it's found in your home directory."
+        'Supply it as argument or use the NOW_TOKEN env variable. ' +
+        '`~/.now/auth.json` will be used, if it\'s found in your home directory.'
       )
     }
 
@@ -97,13 +97,10 @@ class Now {
     })
   }
   getDeployments() {
-    return this.handleRequest(
-      {
-        url: '/now/deployments',
-        method: 'get'
-      },
-      'deployments'
-    )
+    return this.handleRequest({
+      url: '/now/deployments',
+      method: 'get'
+    }, 'deployments')
   }
 
   getDeployment(id) {
@@ -167,13 +164,10 @@ class Now {
   }
 
   getDomains() {
-    return this.handleRequest(
-      {
-        url: '/domains',
-        method: 'get'
-      },
-      'domains'
-    )
+    return this.handleRequest({
+      url: '/domains',
+      method: 'get'
+    }, 'domains')
   }
 
   addDomain(domain) {
@@ -203,13 +197,10 @@ class Now {
   }
 
   getDomainRecords(domain) {
-    return this.handleRequest(
-      {
-        url: `/domains/${domain}/records`,
-        method: 'get'
-      },
-      'records'
-    )
+    return this.handleRequest({
+      url: `/domains/${domain}/records`,
+      method: 'get'
+    }, 'records')
   }
 
   addDomainRecord(domain, recordData) {
@@ -234,13 +225,10 @@ class Now {
       url += `/now/${cn}`
     }
 
-    return this.handleRequest(
-      {
-        url,
-        method: 'get'
-      },
-      'certs'
-    )
+    return this.handleRequest({
+      url,
+      method: 'get'
+    }, 'certs')
   }
 
   createCertificate(cn) {
@@ -273,19 +261,16 @@ class Now {
   }
 
   replaceCertificate(cn, cert, key, ca) {
-    return this.handleRequest(
-      {
-        url: '/now/certs',
-        method: 'put',
-        body: {
-          domains: [cn],
-          ca,
-          cert,
-          key
-        }
-      },
-      'created'
-    )
+    return this.handleRequest({
+      url: '/now/certs',
+      method: 'put',
+      body: {
+        domains: [cn],
+        ca,
+        cert,
+        key
+      }
+    }, 'created')
   }
 
   deleteCertificate(cn) {
@@ -306,13 +291,10 @@ class Now {
       url = `/now/deployments/${id}/aliases`
     }
 
-    return this.handleRequest(
-      {
-        url,
-        method: 'get'
-      },
-      'aliases'
-    )
+    return this.handleRequest({
+      url,
+      method: 'get'
+    }, 'aliases')
   }
 
   createAlias(id, alias) {
@@ -345,13 +327,10 @@ class Now {
   }
 
   getSecrets() {
-    return this.handleRequest(
-      {
-        url: '/now/secrets',
-        method: 'get'
-      },
-      'secrets'
-    )
+    return this.handleRequest({
+      url: '/now/secrets',
+      method: 'get'
+    }, 'secrets')
   }
 
   createSecret(name, value) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ class Now {
       console.error(
         'No token found! ' +
         'Supply it as argument or use the NOW_TOKEN env variable. ' +
-        '`~/.now.json` will be used, if it\'s found in your home directory.'
+        '`~/.now/auth.json` will be used, if it\'s found in your home directory.'
       )
     }
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ const NowClient = require('now-client')
 
 Then initialize it:
 
-- `<token>` holds your token, which can obtained [here](https://zeit.co/account#api-tokens) (optional, will read from `~/.now.json` if not defined - you can also define it using the `NOW_TOKEN` environment variable)
+- `<token>` holds your token, which can obtained [here](https://zeit.co/account#api-tokens) (optional, will read from `~/.now/auth.json` if not defined - you can also define it using the `NOW_TOKEN` environment variable)
 - `<team>` specifies the ID of the team to which the actions should apply (optional)
 
 ```js


### PR DESCRIPTION
According to the now-cli documentation, the configuration file has moved from `.now.json` to `.now/auth.json`.

This is a follow up to #74 to update the docs and fix a bug that I inadvertently introduced:
In my initial PR, I overlooked that the `credentials` property in the `.now/auth.json` actually holds an array: 
```js
{
  "_": "This is your Now credentials file. DON'T SHARE! More: https://git.io/v5ECz",
  "credentials": [
    {
      "provider": "sh",
      "token": "************************"
    }
  ]
}
```

Are there cases when this array holds more than one token? I am logged into two `now` accounts, but the array only contains one object.
For now (no pun intended) I've changed the code to get the first token in the array. I'm sure you know better whether there is a possibility for multiple tokens, in which case the code would need to be adapted further. 
  
  