### PR TITLE
Streams API

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-staged": "git diff --diff-filter=ACMRT --cached --name-only '*.js' | xargs eslint --fix"
   },
   "dependencies": {
-    "js-sha1": "^0.6.0"
+    "crypto-js": "^3.1.9-1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/index.js
+++ b/src/index.js
@@ -101,13 +101,6 @@ function prepareFiles(files) {
  */
 function upload(files, token) {
   return Promise.all(files.map(async file => {
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(file.data)
-        controller.close()
-      }
-    })
-
     const res = await fetch('https://api.zeit.co/v2/now/files', {
       method: 'POST',
       headers: {
@@ -115,7 +108,7 @@ function upload(files, token) {
         'Content-Length': file.data.length,
         'x-now-digest': file.sha,
       },
-      body: stream
+      body: file.data
     })
 
     return res.json()
@@ -254,7 +247,7 @@ export default class Deployment {
       if (!finalMetadata.builds && !finalMetadata.version && !finalMetadata.name) {
         finalMetadata.builds = [{ src: "**", use: "@now/static" }]
         finalMetadata.version = 2
-        finalMetadata.name = files[0].name
+        finalMetadata.name = files.length === 1 ? 'file' : files[0].name
       }
 
       if (finalMetadata.version !== 2) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
-import sha1 from 'js-sha1'
+import uploadFile from './upload'
 
 const _ = Symbol('Deployment')
 
 const ALLOWED_EVENTS = new Set([
   'deployment-state-changed',
   'build-state-changed',
+  'default-to-static',
   'created',
   'ready',
   'error'
@@ -12,109 +13,50 @@ const ALLOWED_EVENTS = new Set([
 
 const API = 'https://api.zeit.co/v8/now/deployments'
 
-/**
- * Read file contents and return a promise
- *
- * @param {Blob} file - file to read
- * @returns {Promise}
- */
-function readFile(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-  
-    reader.onerror = reject
-    reader.onload = (e) => {
-      resolve({
-        name: file.name,
-        data: e.target.result,
-      })
-    }
-  
-    if (file.name === 'now.json') {
-      reader.readAsText(file)
-    } else {
-      reader.readAsArrayBuffer(file)
-    }
-  })
-}
+function parseNowJSON(data) {
+  try {
+    const jsonString = String.fromCharCode.apply(null, new Uint8Array(data))
 
-function getFileName(file) {
-  if (!file.webkitRelativePath || file.webkitRelativePath.length === 0) {
-    return file.name
+    return JSON.parse(jsonString)
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+
+    return {}
   }
-  
-  const [, ...path] = file.webkitRelativePath.split('/')
-
-  return path.join('/')
 }
 
 /**
- * Prepare files for upload, calculate SHA, get metadata from now.json
+ * Prepare and upload files, get metadata from now.json
  *
- * @param {*} files
+ * @param {FileList} files - FileList object from input or drop event 
+ * @param {string} token - ZEIT API token
  * @returns {Promise}
  */
-function prepareFiles(files) {
+function prepare(files, token) {
   return new Promise(async (resolve, reject) => {
     try {
       const promises = []
 
       for (let i = 0; i < files.length; i++) {
-        const file = files.item(i)
-
-        promises.push(readFile(file))
+        promises.push(uploadFile(files.item(i), token))
       }
 
-      const loadedFiles = await Promise.all(promises)
-      const prepFiles = []
-      
-      loadedFiles.forEach(file => {
-        const sha = sha1(file.data)
+      const uploadedFiles = await Promise.all(promises)
   
-        prepFiles.push({
-          ...file,
-          name: getFileName(file),
-          sha
-        })
-      })
-  
-      let nowJson = prepFiles.find(({ name }) => name === 'now.json')
+      let nowJson = uploadedFiles.find(({ name }) => name === 'now.json')
       let metadata = {}
       
       if (nowJson) {
-        metadata = JSON.parse(nowJson.data)
+        metadata = parseNowJSON(nowJson.data)
       }
   
-      resolve([prepFiles, metadata])
+      resolve([uploadedFiles, metadata])
     } catch (e) {
       reject(e)
     }
   })
 } 
-
-/**
- * Upload prepared files to Now
- *
- * @param {*} files - Prepared files
- * @param {string} token - ZEIT API token
- * @returns
- */
-function upload(files, token) {
-  return Promise.all(files.map(async file => {
-    const res = await fetch('https://api.zeit.co/v2/now/files', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Length': file.data.length,
-        'x-now-digest': file.sha,
-      },
-      body: file.data
-    })
-
-    return res.json()
-  }))
-}
-
 
 /**
  * Create a deployment with prepared and uploaded files
@@ -138,8 +80,8 @@ async function createDeployment(files, token, metadata_) {
       ...metadata,
       files: files.map(file => ({
         file: file.name,
-        sha: file.sha,
-        size: file.data.length || file.data.byteLength
+        sha: file.sha1,
+        size: file.length
       }))
     })
   })
@@ -239,7 +181,7 @@ export default class Deployment {
     }
 
     try {
-      const [files, metadata] = await prepareFiles(this.files)
+      const [files, metadata] = await prepare(this.files, this[_].token)
 
       // Merge now.json metadata and provided metadata if any
       const finalMetadata = { ...metadata, ...this.metadata }
@@ -248,6 +190,8 @@ export default class Deployment {
         finalMetadata.builds = [{ src: "**", use: "@now/static" }]
         finalMetadata.version = 2
         finalMetadata.name = files.length === 1 ? 'file' : files[0].name
+        
+        this.fireListeners('default-to-static', finalMetadata)
       }
 
       if (finalMetadata.version !== 2) {
@@ -257,7 +201,7 @@ export default class Deployment {
         throw new DeploymentError(err)
       }
 
-      await upload(files, this[_].token)
+      // await upload(files, this[_].token)
       const { deployment, error } = await createDeployment(files, this[_].token, finalMetadata)
       
       if (error) {

--- a/src/stream-tools.js
+++ b/src/stream-tools.js
@@ -1,0 +1,85 @@
+const noop = () => {}
+
+/**
+ * Read file in chunks as a stream
+ *
+ * @export
+ * @param {File} file - File object
+ * @param {object} options - Read options
+ * @returns {ReadableStream}
+ */
+export function readAsStream(file, options = {}) {
+  const {
+    chunkSize = 1024,
+    binary = true,
+    onChunkError = noop,
+    onSuccess = noop,
+  } = options
+
+  let offset = 0
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Read slice of the file and pass it to the handler
+      const readBlock = (_offset, length, _file) => {
+        const reader = new FileReader()
+        const blob = _file.slice(_offset, length + _offset)
+        
+        reader.onload = onChunkHandler
+        
+        if (binary) {
+          reader.readAsArrayBuffer(blob)
+        } else {
+          reader.readAsText(blob)
+        }
+      }
+
+      // Handle chunk
+      const onChunkHandler = evt => {
+        if (evt.target.error == null) {
+          offset += evt.target.result.length || evt.target.result.byteLength
+          controller.enqueue(evt.target.result)
+        } else {
+          onChunkError(evt.target.error)
+          return
+        }
+        if (offset >= file.size) {
+          // If we're done reading the file, fire a success callback and close the stream
+          onSuccess(file)
+          controller.close()
+
+          return
+        }
+
+        readBlock(offset, chunkSize, file)
+      }
+
+      readBlock(offset, chunkSize, file)
+    }
+  })
+
+  return stream
+}
+
+/**
+ * Concatenate two ArrayBuffers
+ *
+ * @export
+ * @param {ArrayBuffer} buffer1
+ * @param {ArrayBuffer} buffer2
+ * @returns
+ */
+export function concatArrayBuffers(buffer1, buffer2) {
+  if (!buffer1) {
+    return buffer2
+  } else if (!buffer2) {
+    return buffer1
+  }
+
+  const tmp = new Uint8Array(buffer1.byteLength + buffer2.byteLength)
+
+  tmp.set(new Uint8Array(buffer1), 0)
+  tmp.set(new Uint8Array(buffer2), buffer1.byteLength)
+
+  return tmp.buffer
+}

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,0 +1,86 @@
+import crypto from 'crypto-js'
+import { readAsStream, concatArrayBuffers } from './stream-tools'
+
+
+/**
+ * Get the name of a file
+ *
+ * @param {File} file - File object from the input
+ * @returns
+ */
+function getFileName(file) {
+  if (!file.webkitRelativePath || file.webkitRelativePath.length === 0) {
+    return file.name
+  }
+  
+  const [, ...path] = file.webkitRelativePath.split('/')
+
+  return path.join('/')
+}
+
+
+/**
+ * Upload file to Now
+ *
+ * @export
+ * @param {File} file - File object from the input
+ * @param {string} token - ZEIT API token
+ * @returns
+ */
+export default function uploadFile(file, token) {
+  return new Promise((resolve, reject) => {
+    const stream = readAsStream(file)
+    const reader = stream.getReader()
+
+    // Prepare
+    let streamResult = new Uint8Array()
+    const sha = crypto.algo.SHA1.create()
+  
+    // Start reading data from the stream
+    reader.read().then(function processStream({ done, value }) {
+      // If the stream is over, calculate SHA1 and upload the file
+      if (done) {
+        reader.releaseLock() // Release lock so `fetch` can read the stream
+
+        const length = streamResult.byteLength
+        const sha1 = sha.finalize().toString()
+
+        const req = new Request('https://api.zeit.co/v2/now/files', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': length,
+            'x-now-digest': sha1
+          }
+        })
+  
+        req.body = stream
+  
+        // Upload stream
+        fetch(req).then(async res => {
+          const { error } = await res.json()
+          
+          if (error) {
+            return reject(error)
+          }
+
+          return resolve({
+            length,
+            sha1,
+            name: getFileName(file),
+            data: streamResult
+          })
+        })
+        
+        return
+      }
+  
+      // If we're not done yet, update SHA1, append data to the result and continue reading
+      sha.update(crypto.lib.WordArray.create(value))
+      streamResult = concatArrayBuffers(streamResult, value)
+  
+      return reader.read().then(processStream)
+    })
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,6 +1406,11 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2206,11 +2211,6 @@ js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
-
-js-sha1@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/js-sha1/-/js-sha1-0.6.0.tgz#adbee10f0e8e18aa07cdea807cf08e9183dbc7f9"
-  integrity sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR implements the following changes:

- Use Streams API for reading/uploading files
- Make single-file deployments default to `file` name to be consistent with Now Desktop <5
- Add an event to notify about defaulting to `@now/static`
