### PR TITLE
Add support for `fullPath` property for files

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -9,6 +9,10 @@ import { readAsStream, concatArrayBuffers } from './stream-tools'
  * @returns
  */
 function getFileName(file) {
+  if (file.fullPath) {
+    return file.fullPath
+  }
+
   if (!file.webkitRelativePath || file.webkitRelativePath.length === 0) {
     return file.name
   }


### PR DESCRIPTION
This PR allows setting `fullPath` property on `File` objects passed to deployment.
This will allow passing freeform `FileList` and setting file paths for deployment source arbitrarily, which is important for whole-directory deployments