### PR TITLE
.nowignore, wildcard event, file array

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint-staged": "git diff --diff-filter=ACMRT --cached --name-only '*.js' | xargs eslint --fix"
   },
   "dependencies": {
-    "crypto-js": "^3.1.9-1"
+    "crypto-js": "^3.1.9-1",
+    "ignore": "^5.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import uploadFile from './upload'
+import { parseNowJSON, getNowIgnore } from './now-tools'
 
 const _ = Symbol('Deployment')
 
@@ -13,35 +14,25 @@ const ALLOWED_EVENTS = new Set([
 
 const API = 'https://api.zeit.co/v8/now/deployments'
 
-function parseNowJSON(data) {
-  try {
-    const jsonString = String.fromCharCode.apply(null, new Uint8Array(data))
-
-    return JSON.parse(jsonString)
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(e)
-
-    return {}
-  }
-}
-
 /**
  * Prepare and upload files, get metadata from now.json
  *
- * @param {FileList} files - FileList object from input or drop event 
+ * @param {FileList|File[]} files - FileList object from input or drop event 
  * @param {string} token - ZEIT API token
  * @returns {Promise}
  */
 function prepare(files, token) {
   return new Promise(async (resolve, reject) => {
     try {
+      const nowIgnore = await getNowIgnore(files)
       const isArray = Array.isArray(files)
-      const promises = isArray ? files.map(file => uploadFile(file, token)) : []
+      const promises = isArray ? files.filter(file => !nowIgnore.ignores(file.name)).map(file => uploadFile(file, token)) : []
 
       if (!isArray) {
         for (let i = 0; i < files.length; i++) {
-          promises.push(uploadFile(files.item(i), token))
+          if (!nowIgnore.ignores(files.item(i).name)) {
+            promises.push(uploadFile(files.item(i), token))
+          }
         }
       }
 
@@ -291,7 +282,7 @@ export default class Deployment {
 
   fireListeners = (event, data) => {
     this[_].listeners.forEach(listener => {
-      if (listener.event === event) {
+      if (listener.event === event || listener.event === '*') {
         listener.handler(data)
       }
     })

--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,13 @@ function parseNowJSON(data) {
 function prepare(files, token) {
   return new Promise(async (resolve, reject) => {
     try {
-      const promises = []
+      const isArray = Array.isArray(files)
+      const promises = isArray ? files.map(file => uploadFile(file, token)) : []
 
-      for (let i = 0; i < files.length; i++) {
-        promises.push(uploadFile(files.item(i), token))
+      if (!isArray) {
+        for (let i = 0; i < files.length; i++) {
+          promises.push(uploadFile(files.item(i), token))
+        }
       }
 
       const uploadedFiles = await Promise.all(promises)

--- a/src/now-tools.js
+++ b/src/now-tools.js
@@ -1,0 +1,43 @@
+import ignore from 'ignore'
+
+function readFile(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+  
+    reader.onerror = reject
+    reader.onload = (e) => {
+      resolve(e.target.result)
+    }
+  
+    reader.readAsText(file)
+  })
+}
+
+export function parseNowJSON(data) {
+  try {
+    const jsonString = String.fromCharCode.apply(null, new Uint8Array(data))
+
+    return JSON.parse(jsonString)
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+
+    return {}
+  }
+}
+
+export async function getNowIgnore(files) {
+  const isArray = Array.isArray(files)
+  for (let i = 0; i < files.length; i++) {
+    const file = isArray ? files[i] : files.item(i)
+    if (file.name === '.nowignore') {
+      const contents = await readFile(file)
+
+      const ig = ignore().add(contents.split('\n'))
+
+      return ig
+    }
+  }
+
+  return () => false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,11 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+ignore@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.1.tgz#2fc6b8f518aff48fef65a7f348ed85632448e4a5"
+  integrity sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==
+
 iltorb@^2.0.5:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/iltorb/-/iltorb-2.4.3.tgz#b489689d24c8a25a2cf170c515f97954edd45577"


### PR DESCRIPTION
This PR adds the following:

- Parse and respect `.nowignore` if found in files
- Support for `.on('*')` for subscribing to all events
- Support an option of passing an array of files instead of a `FileList`