### PR TITLE
Don't stream files that are too small

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ export default class Deployment {
       
       return deployment
     } catch (e) {
-      const err = { code: 'unexpected_error', message: e.toString() }
+      const err = { code: e.code || 'unexpected_error', message: e.message || e.toString() }
       this.fireListeners('error', err)
     }
   }

--- a/src/stream-tools.js
+++ b/src/stream-tools.js
@@ -1,5 +1,17 @@
 const noop = () => {}
 
+const read = (file, binary) => new Promise(resolve => {
+  const reader = new FileReader()
+
+  reader.onload = resolve
+
+  if (binary) {
+    reader.readAsArrayBuffer(file)
+  } else {
+    reader.readAsText(file)
+  }
+})
+
 /**
  * Read file in chunks as a stream
  *
@@ -8,13 +20,17 @@ const noop = () => {}
  * @param {object} options - Read options
  * @returns {ReadableStream}
  */
-export function readAsStream(file, options = {}) {
+export function readFile(file, options = {}) {
   const {
     chunkSize = 1024,
     binary = true,
     onChunkError = noop,
     onSuccess = noop,
   } = options
+
+  if (file.size <= chunkSize) {
+    return read(file, binary)
+  }
 
   let offset = 0
 


### PR DESCRIPTION
This PR ensures that files that are smaller than the stream chunk size are uploaded as a whole instead of being streamed, which fixes the SHA1 validation issue