### PR TITLE
Add defaultName property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,9 @@ export default class Deployment {
    * @memberof Deployment
    */
   constructor(files, token = null, metadata = {}) {
-    this.metadata = metadata
+    const { defaultName, ...metadata_ } = metadata
+    this.metadata = metadata_
+    this.defaultName = defaultName
     this.files = files
     this.preparedFiles = []
 
@@ -195,6 +197,10 @@ export default class Deployment {
         finalMetadata.name = files.length === 1 ? 'file' : files[0].name
         
         this.fireListeners('default-to-static', finalMetadata)
+      }
+
+      if (!finalMetadata.name) {
+        finalMetadata.name = this.defaultName || files[0].name
       }
 
       if (finalMetadata.version !== 2) {


### PR DESCRIPTION
This PR adds `defaultName` property to deployment options that will be used as a deployment name if one isn't provided in `now.json`