### PR TITLE
CLI required tweaks

### DIFF
--- a/src/create-deployment.ts
+++ b/src/create-deployment.ts
@@ -8,7 +8,7 @@ import { DeploymentError } from './errors'
 
 export { EVENTS } from './utils'
 
-export default function buildCreateDeployment(version: number) {
+export default function buildCreateDeployment(version: number): CreateDeploymentFunction {
   return async function* createDeployment(
     path: string | string[],
     options: DeploymentOptions = {}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -51,7 +51,7 @@ async function* createDeployment(
 
     if (!dpl.ok || json.error) {
       // Return error object
-      return yield { type: 'error', payload: json.error || json }
+      return yield { type: 'error', payload: json.error ? { ...json.error, status: dpl.status } : { ...json, status: dpl.status } }
     }
 
     yield { type: 'created', payload: json }

--- a/src/deployment-status.ts
+++ b/src/deployment-status.ts
@@ -60,19 +60,23 @@ export default async function* checkDeploymentStatus(
     } else {
       // Deployment polling
       const deploymentData = await fetch(
-        `${apiDeployments}/${deployment.id}${
+        `${apiDeployments}/${deployment.id || deployment.deploymentId}${
           teamId ? `?teamId=${teamId}` : ''
         }`,
         token
       );
       const deploymentUpdate = await deploymentData.json();
 
+      if (deploymentUpdate.error) {
+        return yield { type: 'error', payload: deploymentUpdate.error }
+      }
+
       if (isReady(deploymentUpdate)) {
         return yield { type: 'ready', payload: deploymentUpdate };
       }
 
       if (isFailed(deploymentUpdate)) {
-        return yield { type: 'error', payload: deploymentUpdate };
+        return yield { type: 'error', payload: deploymentUpdate.error || deploymentUpdate };
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import buildCreateDeployment from './create-deployment';
+import buildCreateDeployment from './create-deployment'
 
-export const createDeployment = buildCreateDeployment(1);
-export const createLegacyDeployment = buildCreateDeployment(2);
-export * from './errors';
+export const createDeployment = buildCreateDeployment(2)
+export const createLegacyDeployment = buildCreateDeployment(1)
+export * from './errors'

--- a/src/utils/ready-state.ts
+++ b/src/utils/ready-state.ts
@@ -1,3 +1,3 @@
-export const isReady = ({ readyState }: Deployment | DeploymentBuild): boolean => readyState === 'READY'
-export const isFailed = ({ readyState }: Deployment | DeploymentBuild): boolean => readyState.endsWith('_ERROR') || readyState === 'ERROR'
+export const isReady = ({ readyState, state }: Deployment | DeploymentBuild): boolean => readyState === 'READY' || state === 'READY'
+export const isFailed = ({ readyState, state }: Deployment | DeploymentBuild): boolean => readyState ? (readyState.endsWith('_ERROR') || readyState === 'ERROR') : (state && state.endsWith('_ERROR') || state === 'ERROR')
 export const isDone = (buildOrDeployment: Deployment | DeploymentBuild): boolean => isReady(buildOrDeployment) || isFailed(buildOrDeployment)

--- a/tests/create-legacy-deployment.test.ts
+++ b/tests/create-legacy-deployment.test.ts
@@ -10,7 +10,7 @@ describe('create v1 deployment', () => {
   afterEach(async () => {
     if (deployment) {
       const response = await fetch(
-        `${API_DELETE_DEPLOYMENTS_LEGACY}/${deployment.deploymentId}`,
+        `${API_DELETE_DEPLOYMENTS_LEGACY}/${deployment.deploymentId || deployment.uid}`,
         TOKEN,
         {
           method: 'DELETE'
@@ -32,7 +32,7 @@ describe('create v1 deployment', () => {
       if (event.type === 'ready') {
         deployment = event.payload
         if (deployment) {
-          expect(deployment.readyState).toEqual('READY')
+          expect(deployment.readyState || deployment.state).toEqual('READY')
           break
         }
       }
@@ -50,7 +50,7 @@ describe('create v1 deployment', () => {
       if (event.type === 'ready') {
         deployment = event.payload
         if (deployment) {
-          expect(deployment.readyState).toEqual('READY')
+          expect(deployment.readyState || deployment.state).toEqual('READY')
           break
         }
       }
@@ -68,7 +68,7 @@ describe('create v1 deployment', () => {
       if (event.type === 'ready') {
         deployment = event.payload
         if (deployment) {
-          expect(deployment.readyState).toEqual('READY')
+          expect(deployment.readyState || deployment.state).toEqual('READY')
           break
         }
       }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -16,6 +16,7 @@ interface Build {
 export interface Deployment {
   id: string;
   deploymentId?: string;
+  uid?: string;
   url: string;
   name: string;
   meta: {
@@ -29,6 +30,13 @@ export interface Deployment {
   public: boolean;
   ownerId: string;
   readyState:
+  | 'INITIALIZING'
+  | 'ANALYZING'
+  | 'BUILDING'
+  | 'DEPLOYING'
+  | 'READY'
+  | 'ERROR';
+  state?:
   | 'INITIALIZING'
   | 'ANALYZING'
   | 'BUILDING'

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -15,6 +15,7 @@ declare interface Build {
 
 declare interface Deployment {
   id: string;
+  deploymentId?: string;
   url: string;
   name: string;
   meta: {
@@ -28,6 +29,13 @@ declare interface Deployment {
   public: boolean;
   ownerId: string;
   readyState:
+  | 'INITIALIZING'
+  | 'ANALYZING'
+  | 'BUILDING'
+  | 'DEPLOYING'
+  | 'READY'
+  | 'ERROR';
+  state?:
   | 'INITIALIZING'
   | 'ANALYZING'
   | 'BUILDING'
@@ -54,6 +62,13 @@ declare interface DeploymentBuild {
   createdIn: string;
   deployedTo: string;
   readyState:
+  | 'INITIALIZING'
+  | 'ANALYZING'
+  | 'BUILDING'
+  | 'DEPLOYING'
+  | 'READY'
+  | 'ERROR';
+  state?:
   | 'INITIALIZING'
   | 'ANALYZING'
   | 'BUILDING'
@@ -100,3 +115,5 @@ declare interface NowJsonOptions {
   type?: 'NPM' | 'STATIC' | 'DOCKER';
   version?: number;
 }
+
+declare type CreateDeploymentFunction = (path: string | string[], options?: DeploymentOptions) => AsyncIterableIterator<any>;


### PR DESCRIPTION
This implements a few changes required for Now CLI:

- Pass HTTP status to `error` payloads
- Use `deploymentId` instead of `id` for legacy deployments
- Handle legacy errors
- Handle legacy deployment state checks
- Fix `createDeployment` and `createLegacyDeployment` being flipped